### PR TITLE
Refactor output paths for analytical dataset and save processed files

### DIFF
--- a/oulad-analysis/data/processed/analytical_dataset.csv
+++ b/oulad-analysis/data/processed/analytical_dataset.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0189368a824955ee277589eff0f292a921d748166b09f3f11b7c93f48b5d14a0
+size 5492752

--- a/oulad-analysis/data/processed/analytical_dataset.rds
+++ b/oulad-analysis/data/processed/analytical_dataset.rds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7554df975e0db236a70712d1ee8b32b8f3b79426d00d53eaa7293107fcd06a05
+size 770457

--- a/oulad-analysis/notebooks/00_data_pipeline/03_data_cleaning.R
+++ b/oulad-analysis/notebooks/00_data_pipeline/03_data_cleaning.R
@@ -414,8 +414,8 @@ print(dim(analytical_df))
 # RDS: preserves factor levels and ordering exactly
 #      loading the CSV later would lose all encoding and we'd redo it
 
-write_csv(analytical_df, "outputs/data/analytical_dataset.csv")
-saveRDS(analytical_df,   "outputs/data/analytical_dataset.rds")
+write_csv(analytical_df, "data/processed/analytical_dataset.csv")
+saveRDS(analytical_df,   "data/processed/analytical_dataset.rds")
 
 
 


### PR DESCRIPTION
This pull request updates the data output paths in the data cleaning notebook and adds new versions of the processed analytical dataset in both CSV and RDS formats to the repository. The most important changes are:

**Data output path updates:**

* Changed the output directory for saving the processed dataset from `outputs/data/` to `data/processed/` in the `03_data_cleaning.R` notebook, ensuring consistency with the repository's data organization.

**Addition of processed data files:**

* Added a new version of the processed analytical dataset in CSV format (`analytical_dataset.csv`) to the `data/processed/` directory, tracked via Git LFS.
* Added a new version of the processed analytical dataset in RDS format (`analytical_dataset.rds`) to the `data/processed/` directory, tracked via Git LFS.